### PR TITLE
support for specifying custom file path to log the error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # Goland
 /.idea
+
+/dist/
+/example/log*
+/example/log*/

--- a/example/custom_log_file.go
+++ b/example/custom_log_file.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/ichtrojan/thoth"
+    "errors"
+)
+
+func main() {
+	logger := thoth.Init("./logs/logger.log.txt")
+    err := errors.New("Test Custom Error log")
+    logger.Log(err)
+}

--- a/thoth.go
+++ b/thoth.go
@@ -6,22 +6,27 @@ import (
 	"time"
 )
 
-const directory = "logs"
-
 type Config struct {
 	directory string
 }
 
-func Init() Config {
-	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		err = os.MkdirAll(directory, 0755)
+func Init(params ...string) Config {
+    path := ""
+    
+    if (len(params) > 0) {
+        path = params[0]
+    } else {
+        directory := "logs"
+        if _, err := os.Stat(directory); os.IsNotExist(err) {
+            err = os.MkdirAll(directory, 0755)
 
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
+            if err != nil {
+                fmt.Println(err)
+            }
+        }
 
-	path := fmt.Sprintf("%s/error.log", directory)
+        path = fmt.Sprintf("%s/error.log", directory)
+    }
 
 	var _, err = os.Stat(path)
 


### PR DESCRIPTION
#### What does this PR do

Extend the `Init` function to accept a custom file log path.
Before this PR the package only logs the error in a `log/error.log` file created in relative to the project run directory. 

#### Testing 

```go
go install ./
go run ./example/custom_log_file.go
```

This will create a `logger.log.txt` file that contains the error